### PR TITLE
Fix: Force word wrapping in output box

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,8 +171,9 @@
             font-size: 14px;
             line-height: 1.5;
             background: transparent !important;
-            white-space: pre-wrap;
+            white-space: pre-wrap !important;
             word-wrap: break-word;
+            word-break: break-all !important;
             min-height: calc(100% - 30px);
             box-sizing: border-box;
         }
@@ -182,8 +183,9 @@
             background: transparent !important;
             padding: 0 !important;
             border-radius: 0 !important;
-            white-space: pre-wrap;
+            white-space: pre-wrap !important;
             word-wrap: break-word;
+            word-break: break-all !important;
         }
 
         /* Dark mode Prism adjustments with green accents */


### PR DESCRIPTION
The beautified output code was not wrapping correctly, causing horizontal scrolling on long lines. This was likely due to CSS specificity conflicts with the syntax highlighting library.

This change adds `word-break: break-all !important;` and `white-space: pre-wrap !important;` to the CSS for the output container. These forceful styles ensure that long, unbreakable strings will wrap to the next line and that the wrapping behavior is not overridden.